### PR TITLE
Allow Queues to be consumed as Stream

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,7 @@
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches: ["main"]
 
 name: CI
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,16 @@ license = "MIT"
 [dependencies]
 async-trait = "0.1"
 url = "2"
+futures = "0.3"
+pin-project-lite = "0.2"
 
-# Rabbitmq deps
+# Optional deps for specific queue implementations
 lapin = { version = "2", optional = true }
 snafu = { version = "0.7", optional = true }
 tokio = { version = "1", features = [ "sync", "rt" ], optional = true }
-futures = { version = "0.3", optional = true }
 uuid = { version = "1", optional = true, features = [ "v4" ] }
 tracing = { version = "0.1", optional = true }
+postage = { version = "0.5", default-features = false, features = [ "futures-traits" ], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = [ "time", "macros" ] }
@@ -25,5 +27,5 @@ test-log = { version = "0.2", default-features = false, features = [ "trace" ] }
 tracing-subscriber = { version = "0.3", features = [ "env-filter" ] }
 
 [features]
-rabbitmq = [ "lapin", "snafu", "tokio", "futures", "uuid", "tracing" ]
-local = [ "tokio", "snafu" ]
+rabbitmq = [ "lapin", "snafu", "tokio", "uuid", "tracing" ]
+local = [ "snafu", "postage", "tokio", "tracing" ]

--- a/src/amqp.rs
+++ b/src/amqp.rs
@@ -266,32 +266,18 @@ mod test {
 
     use std::time::Duration;
 
-    use lapin::{Channel, Connection, ConnectionProperties};
-
     fn make_job_data() -> Vec<u8> {
         String::from("test-message").into_bytes()
     }
 
-    /// Get a rabbit mq connection to some server for integration tests
-    pub async fn rabbit_mq_connection() -> Channel {
-        let addr = option_env!("AMQP_ADDR").unwrap_or("amqp://localhost:5672");
-
-        let conn = Connection::connect(addr, ConnectionProperties::default())
-            .await
-            .expect("failed to connect to rabbitmq");
-
-        conn.create_channel()
-            .await
-            .expect("could not create rabbitmq channel")
-    }
-
     /// Create a queue with a given name
     pub async fn create_queue(name: &str) -> impl JobQueue {
-        let channel = rabbit_mq_connection().await;
+        let addr = option_env!("AMQP_ADDR").unwrap_or("amqp://localhost:5672");
 
-        AmqpJobQueue::new(name, channel)
+        MakeRabbitJobQueue
+            .make_job_queue(name, addr.parse().unwrap())
             .await
-            .expect("could not create job queue")
+            .expect("failed to create rabbit queue")
     }
 
     #[test_log::test(tokio::test)]

--- a/src/local.rs
+++ b/src/local.rs
@@ -1,21 +1,38 @@
-use std::collections::VecDeque;
-use std::sync::Arc;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
 
-use tokio::sync::RwLock;
+use futures::prelude::*;
+
+use pin_project_lite::pin_project;
+
+use postage::dispatch;
 
 use tracing::*;
 
 use url::Url;
 
-use super::{JobHandle, JobQueue, JobResult, MakeJobQueue};
+use super::{Consumer, JobHandle, JobQueue, JobResult, MakeJobQueue};
 
 #[derive(snafu::Snafu, Debug)]
 pub struct LocalError;
 
 /// A local job queue used for testing
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct LocalJobQueue {
-    queue: Arc<RwLock<VecDeque<Vec<u8>>>>,
+    in_queue: dispatch::Receiver<Vec<u8>>,
+    out_queue: dispatch::Sender<Vec<u8>>,
+}
+
+impl Default for LocalJobQueue {
+    fn default() -> LocalJobQueue {
+        let (out_queue, in_queue) = dispatch::channel(64);
+
+        Self {
+            in_queue,
+            out_queue,
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -24,11 +41,19 @@ impl JobQueue for LocalJobQueue {
 
     type Handle = ();
 
+    type Consumer = LocalConsumer;
+
     async fn put_job<D>(&self, data: D) -> Result<(), Self::Err>
     where
         D: AsRef<[u8]> + Send,
     {
-        self.queue.write().await.push_back(data.as_ref().to_vec());
+        let data = data.as_ref().to_vec();
+
+        self.out_queue
+            .clone()
+            .send(data)
+            .await
+            .map_err(|_| LocalError)?;
 
         debug!("registered new job");
 
@@ -37,7 +62,7 @@ impl JobQueue for LocalJobQueue {
 
     async fn get_job(&self) -> Result<JobResult<Self::Handle>, Self::Err> {
         loop {
-            if let Some(job) = self.queue.write().await.pop_front() {
+            if let Some(job) = self.in_queue.clone().next().await {
                 debug!("removed job from queue");
 
                 break Ok(JobResult::new(job, ()));
@@ -45,6 +70,10 @@ impl JobQueue for LocalJobQueue {
 
             tokio::task::yield_now().await;
         }
+    }
+
+    async fn consumer(&self) -> Self::Consumer {
+        LocalConsumer::new(self.in_queue.clone())
     }
 }
 
@@ -77,6 +106,41 @@ impl MakeJobQueue for MakeLocalQueue {
     }
 }
 
+pin_project! {
+    /// A queue [`Consumer`] for [`LocalJobQueue`]
+    ///
+    /// [`Consumer`]: crate::Consumer
+    /// [`LocalJobQueue`]: LocalJobQueue
+    pub struct LocalConsumer {
+        #[pin]
+        consumer: dispatch::Receiver<Vec<u8>>,
+    }
+}
+
+impl LocalConsumer {
+    pub(self) fn new(consumer: dispatch::Receiver<Vec<u8>>) -> Self {
+        LocalConsumer { consumer }
+    }
+}
+
+impl Consumer for LocalConsumer {
+    type Handle = ();
+
+    type Err = LocalError;
+}
+
+impl Stream for LocalConsumer {
+    type Item = Result<JobResult<<Self as Consumer>::Handle>, <Self as Consumer>::Err>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project()
+            .consumer
+            .poll_next(cx)
+            .map(|x| x.map(Ok::<_, LocalError>))
+            .map_ok(|data| JobResult::new(data, ()))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -91,5 +155,22 @@ mod test {
         let actual = queue.get_job().await.expect("failed to get job");
 
         assert_eq!(&job, &*actual, "wrong job returned");
+    }
+
+    #[tokio::test]
+    async fn consumer() {
+        let queue = LocalJobQueue::default();
+        let mut consumer = queue.consumer().await;
+        let expected = Vec::new();
+
+        queue.put_job(&expected).await.expect("put_job failed");
+
+        let actual = consumer
+            .next()
+            .await
+            .expect("no job")
+            .expect("failed to get job");
+
+        assert_eq!(&expected, &*actual);
     }
 }


### PR DESCRIPTION
This allows `Queue`s to produce a `Stream` to interface more easily with futures based crates