### PR TITLE
fix(amqp): create queues when opening for input

### DIFF
--- a/src/amqp.rs
+++ b/src/amqp.rs
@@ -165,6 +165,20 @@ impl MakeQueue for MakeRabbitQueue {
             "opening queue for reading"
         );
 
+        channel
+            .queue_declare(
+                name,
+                QueueDeclareOptions {
+                    durable: true,
+                    ..Default::default()
+                },
+                FieldTable::default(),
+            )
+            .await
+            .context(QueueSnafu {
+                name: name.to_string(),
+            })?;
+
         let queue = channel
             .basic_consume(
                 name,


### PR DESCRIPTION
Since basic_consume does not create the queue we run into race conditions when using `InputQueue` if
the corresponding `OutputQueue` has not been created first